### PR TITLE
Add GPL3 license header to mime_map.{cpp,h}

### DIFF
--- a/src/mime_map.cpp
+++ b/src/mime_map.cpp
@@ -1,3 +1,12 @@
+/*
+ * This file is part of tcpflow by Simson Garfinkel <simsong@acm.org>.
+ * Originally by Will Glynn <will@willglynn.com>.
+ *
+ * This source code is under the GNU Public License (GPL) version 3.
+ * See COPYING for details.
+ *
+ */
+
 #include "mime_map.h"
 
 #include <algorithm>

--- a/src/mime_map.h
+++ b/src/mime_map.h
@@ -1,3 +1,12 @@
+/*
+ * This file is part of tcpflow by Simson Garfinkel <simsong@acm.org>.
+ * Originally by Will Glynn <will@willglynn.com>.
+ *
+ * This source code is under the GNU Public License (GPL) version 3.
+ * See COPYING for details.
+ *
+ */
+
 #ifndef MIME_MAP_H
 #define MIME_MAP_H
 


### PR DESCRIPTION
The Debian maintainer brought to my attention the fact that the `mime_map.{cpp,h}` files I authored have no licensing header. This commit adds one.
