### PR TITLE
new option -0 to omit extra new lines

### DIFF
--- a/src/tcpdemux.h
+++ b/src/tcpdemux.h
@@ -88,7 +88,8 @@ public:
     class options {
     public:;
         enum { MAX_SEEK=1024*1024*16 };
-        options():console_output(false),store_output(true),opt_md5(false),
+        options():console_output(false),console_output_nonewline(false),
+                  store_output(true),opt_md5(false),
                   post_processing(false),gzip_decompress(true),
                   max_bytes_per_flow(),
                   max_flows(0),suppress_header(0),
@@ -96,6 +97,7 @@ public:
                   output_packet_index(false),max_seek(MAX_SEEK) {
         }
         bool    console_output;
+        bool    console_output_nonewline;
         bool    store_output;   // do we output?
         bool    opt_md5;                // do we calculate MD5 on DFXML output?
         bool    post_processing;        // decode headers after tcp connection closes

--- a/src/tcpflow.cpp
+++ b/src/tcpflow.cpp
@@ -124,6 +124,7 @@ static void usage(int level)
     std::cout << "   -B: binary output, even with -c or -C (normally -c or -C turn it off)\n";
     std::cout << "   -c: console print only (don't create files)\n";
     std::cout << "   -C: console print only, but without the display of source/dest header\n";
+    std::cout << "   -0: don't print newlines after packets when printing to console";
     std::cout << "   -s: strip non-printable characters (change to '.')\n";
     std::cout << "   -D: output in hex (useful to combine with -c or -C)\n";
     std::cout << "\n";
@@ -434,7 +435,7 @@ int main(int argc, char *argv[])
 
     bool trailing_input_list = false;
     int arg;
-    while ((arg = getopt(argc, argv, "aA:Bb:cCd:DE:e:E:F:f:gHhIi:lL:m:o:pqR:r:S:sT:Vvw:x:X:Z")) != EOF) {
+    while ((arg = getopt(argc, argv, "aA:Bb:cCd:DE:e:E:F:f:gHhIi:lL:m:o:pqR:r:S:sT:Vvw:x:X:Z:0")) != EOF) {
 	switch (arg) {
 	case 'a':
 	    demux.opt.post_processing = true;
@@ -463,6 +464,9 @@ int main(int argc, char *argv[])
 	    break;
 	case 'c':
 	    demux.opt.console_output = true;	DEBUG(10) ("printing packets to console only");
+	    break;
+    case '0':
+	    demux.opt.console_output_nonewline = true;
 	    break;
 	case 'd':
 	    if ((debug = atoi(optarg)) < 0) {

--- a/src/tcpip.cpp
+++ b/src/tcpip.cpp
@@ -323,7 +323,7 @@ void tcpip::print_packet(const u_char *data, uint32_t length)
 
     if (demux.opt.use_color) printf("\033[0m");
 
-    putchar('\n');
+    if (! demux.opt.console_output_nonewline) putchar('\n');
     fflush(stdout);
 
 #ifdef HAVE_PTHREAD


### PR DESCRIPTION
Hi Simson,

I like to pipe output of tcpflow -C to another tool to process further.

In some situations it's better not to print a newline after every packet - this pull request adds a new option "-0 don't print newlines after packets when printing to console".

Thanks.