### PR TITLE
Added 'len' and 'snap_trunc' to flows and reporting.

### DIFF
--- a/src/tcpdemux.cpp
+++ b/src/tcpdemux.cpp
@@ -490,6 +490,8 @@ int tcpdemux::process_tcp(const ipaddr &src, const ipaddr &dst,sa_family_t famil
     /* Now tcp is valid */
     tcp->myflow.tlast = pi.ts;		// most recently seen packet
     tcp->last_packet_number = packet_counter++;
+    tcp->myflow.len += pi.pcap_hdr->len;
+    tcp->myflow.snap_trunc = tcp->myflow.snap_trunc || (pi.pcap_hdr->len > pi.pcap_hdr->caplen);
     tcp->myflow.packet_count++;
 
     /*

--- a/src/tcpip.cpp
+++ b/src/tcpip.cpp
@@ -79,10 +79,12 @@ void tcpip::dump_xml(class dfxml_writer *xreport,const std::string &xmladd)
     attrs << "dst_ipn='"  << myflow.dst << "' ";
     if(myflow.has_mac_daddr()) attrs << "mac_daddr='" << macaddr(myflow.mac_daddr) << "' ";
     if(myflow.has_mac_saddr()) attrs << "mac_saddr='" << macaddr(myflow.mac_saddr) << "' ";
+    attrs << "len='"      << myflow.len << "' ";
     attrs << "packets='"  << myflow.packet_count << "' ";
     attrs << "srcport='"  << myflow.sport << "' ";
     attrs << "dstport='"  << myflow.dport << "' ";
     attrs << "family='"   << (int)myflow.family << "' ";
+    if (myflow.snap_trunc) attrs << "snap_trunc='true' ";
     if(out_of_order_count) attrs << "out_of_order_count='" << out_of_order_count << "' ";
     if(violations)         attrs << "violations='" << violations << "' ";
 	

--- a/src/tcpip.h
+++ b/src/tcpip.h
@@ -151,12 +151,14 @@ public:;
     static void usage();			// print information on flow notation
     static std::string filename_template;	// 
     static std::string outdir;                  // where the output gets written
-    flow():id(),vlan(),mac_daddr(),mac_saddr(),tstart(),tlast(),packet_count(){};
+    flow():id(),vlan(),mac_daddr(),mac_saddr(),tstart(),tlast(),len(),snap_trunc(),packet_count(){};
     flow(const flow_addr &flow_addr_,uint64_t id_,const be13::packet_info &pi):
 	flow_addr(flow_addr_),id(id_),vlan(pi.vlan()),
         mac_daddr(),
         mac_saddr(),
         tstart(pi.ts),tlast(pi.ts),
+        len(0),
+        snap_trunc(false),
 	packet_count(0){
         if(pi.pcap_hdr){
             memcpy(mac_daddr,pi.get_ether_dhost(),sizeof(mac_daddr));
@@ -170,6 +172,8 @@ public:;
     uint8_t mac_saddr[6];               // source mac address of first packet
     struct timeval tstart;		// when first seen
     struct timeval tlast;		// when last seen
+    uint64_t len;     		        // off-wire length
+    bool snap_trunc;                    // Was the capture snapped by snaplen
     uint64_t packet_count;		// packet count
 
     // return a filename for a flow based on the template and the connection count


### PR DESCRIPTION
I find myself doing quite a bit of processing of PCap flows using 'tcpflow' and then post-processing for other purposes.  In this post-processing it is valuable to have information about the total length of the original captured data, not just the extracted TCP data.

Knowing when packets in a particular flow were truncated by 'snaplen' is also valuable, hence the attribute named 'snap_trunc'.
