### PR TITLE
Fixed incorrect shell in source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you want do download the development tree with git, be sure to do a *complete
 
     git clone --recursive https://github.com/simsong/tcpflow.git
     cd tcpflow
-    sh bootstrap.sh
+    bash bootstrap.sh
     ./configure
     make
     sudo make install  


### PR DESCRIPTION
Following the current instructions, I immediately hit this error:

```
bootstrap.sh: 6: bootstrap.sh: Syntax error: "(" unexpected
```

It may be a result of /bin/sh being dash on ubuntu, but either way, bootstrap.sh's shebang is /bin/bash, so the instructions should reflect that.