### PR TITLE
tcpflow -c should print a dot for non-printable chars

### DIFF
--- a/src/tcpip.cpp
+++ b/src/tcpip.cpp
@@ -310,6 +310,7 @@ void tcpip::print_packet(const u_char *data, uint32_t length)
                 
                 }
 	    }
+	    else fputc('.',stdout);
             written += 1; // treat even unprintable characters as "written". It
                           // really means "processed"
 	}


### PR DESCRIPTION
Older versions of tcpflow would print a dot for each non-printable character when running "tcpflow -c".  The manpage confirms that this is the expected behavior.

The current version doesn't print the dot (or any other character) when encountering non-printable characters.

This quick and dirty Pull Request adds the else statement to print the dot.