### PR TITLE
Improve close_oldest logic

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,6 +81,7 @@ tcpflow_SOURCES = \
 	tcpflow.cpp \
 	tcpip.h tcpip.cpp \
 	tcpdemux.h tcpdemux.cpp \
+	intrusive_list.h \
 	tcpflow.h util.cpp \
 	scan_md5.cpp \
 	scan_http.cpp \

--- a/src/intrusive_list.h
+++ b/src/intrusive_list.h
@@ -1,0 +1,67 @@
+#ifndef INTRUSIVE_LIST_H
+#define INTRUSIVE_LIST_H
+
+#include <iostream>
+#include <list>
+
+// implement boost::intrusive::list using std::list
+
+template <class T>
+class intrusive_list {
+  public:
+  intrusive_list():li(), len(0) {}
+  
+  typedef typename std::list<T*>::iterator iterator;
+  
+  inline void push_back(T* node) {
+    li.push_back(node);
+    len++;
+    node->it = --li.end();
+  }
+
+  inline void erase(T* node) {
+    if (!is_linked(node))
+      return;
+    li.erase(node->it);
+    len--;
+    reset(node);
+  }
+  
+  inline void move_to_end(T* node) {
+    if (!is_linked(node))
+      return;
+    li.splice(li.end(), li, node->it);
+  }
+  
+  inline void reset(T* node) {
+    node->it = li.end();
+  }
+  
+  inline bool empty() {
+    return li.empty();
+  }
+  
+  inline size_t size() {
+    // std::list.size() is O(n) in some platform. Is there any define flag for that?
+    //return li.size();
+    return len;
+  }
+  
+  inline iterator begin() {
+    return li.begin();
+  }
+  
+  inline iterator end() {
+    return li.end();
+  }
+  
+  private:
+  inline bool is_linked(T* node) {
+    return node->it != li.end();
+  }
+  
+  std::list<T*> li;
+  size_t len;
+};
+
+#endif // INTRUSIVE_LIST_H

--- a/src/tcpdemux.h
+++ b/src/tcpdemux.h
@@ -39,6 +39,7 @@
 #endif
 
 #include <queue>
+#include "intrusive_list.h"
 
 /**
  * the tcp demultiplixer
@@ -59,11 +60,9 @@ class tcpdemux {
     } flow_addr_key_eq;
 
 #ifdef HAVE_TR1_UNORDERED_MAP
-    typedef std::tr1::unordered_set<class tcpip *> tcpset;
     typedef std::tr1::unordered_map<flow_addr,tcpip *,flow_addr_hash,flow_addr_key_eq> flow_map_t; // active flows
     typedef std::tr1::unordered_map<flow_addr,saved_flow *,flow_addr_hash,flow_addr_key_eq> saved_flow_map_t; // flows that have been saved
 #else
-    typedef std::unordered_set<class tcpip *> tcpset;
     typedef std::unordered_map<flow_addr,tcpip *,flow_addr_hash,flow_addr_key_eq> flow_map_t; // active flows
     typedef std::unordered_map<flow_addr,saved_flow *,flow_addr_hash,flow_addr_key_eq> saved_flow_map_t; // flows that have been saved
 #endif
@@ -124,7 +123,7 @@ public:
     unsigned int max_fds;               // maximum number of file descriptors for this tcpdemux
 
     flow_map_t  flow_map;               // db of open tcpip objects, indexed by flow
-    tcpset      open_flows;              // the tcpip flows with open files
+    intrusive_list<tcpip> open_flows; // the tcpip flows with open files in access order
 
     saved_flow_map_t saved_flow_map;  // db of saved flows, indexed by flow
     saved_flows_t    saved_flows;     // the flows that were saved

--- a/src/tcpip.cpp
+++ b/src/tcpip.cpp
@@ -150,8 +150,8 @@ void tcpip::close_file()
 #endif
 	close(fd);
 	fd = -1;
+	demux.open_flows.erase(this);           // we are no longer open
     }
-    demux.open_flows.erase(this);           // we are no longer open
     // Also close the flow_index file, if flow indexing is in use --GDD
     if(demux.opt.output_packet_index && idx_file.is_open()){
     	idx_file.close();
@@ -192,7 +192,7 @@ int tcpip::open_file()
             return -1;
         }
         /* Remember that we have this open */
-        demux.open_flows.insert(this);
+        demux.open_flows.push_back(this);
         if(demux.open_flows.size() > demux.max_open_flows) demux.max_open_flows = demux.open_flows.size();
         //std::cerr << "open_file1 " << *this << "\n";
     }

--- a/src/tcpip.h
+++ b/src/tcpip.h
@@ -249,6 +249,8 @@ public:
 typedef boost::icl::interval_set<uint64_t> recon_set; // Boost interval set of bytes that were reconstructed.
 #endif
 
+#include "intrusive_list.h"
+
 #pragma GCC diagnostic warning "-Weffc++"
 #pragma GCC diagnostic warning "-Wshadow"
 #pragma GCC diagnostic warning "-Wall"
@@ -302,6 +304,9 @@ public:;
     uint64_t	last_packet_number;	// for finding most recent packet written
     uint64_t	out_of_order_count;	// all packets were contigious
     uint64_t    violations;		// protocol violation count
+
+    /* File Acess Order */
+    intrusive_list<tcpip>::iterator it;
 
     /* Methods */
     void close_file();			// close fd


### PR DESCRIPTION
Previous code finds oldest to close by looking at timestamp of all tcpips.
I improved this by using list which is kept sorted by access order.
close_oldest_fd() complexity changed from O(size_of_open_flows) -> O(1)
I'm also thinking similar improvement could be applied to tcp_timeout.

This is result.
pcap 520M, Ubuntu 14.04
time tcpflow -S enable_report=NO -r test.pcap -o out

original
/dev/shm 9.518s, disk 11.763s

intrusive_list
/dev/shm 3.800s, disk 5.082s

* Notes about intrusive_list
1. to avoid dependency of boost library, I implemented intrusive_list with std::list instead of using boost::intrusive::list.
2. In some platform std::list.size() is still O(n), so I cached list's size in intrusive_list.