### PR TITLE
Fix bug in shutdown logic

### DIFF
--- a/src/tcpdemux.cpp
+++ b/src/tcpdemux.cpp
@@ -89,23 +89,6 @@ void  tcpdemux::write_flow_record(const std::string &starttime,const std::string
     return theInstance;
 }
 
-
-
-/**
- * Implement a list of open_flows, each with an associated file descriptor.
- * When a new file needs to be opened, we can close a flow if necessary.
- */
-void tcpdemux::close_all_fd()
-{
-    tcpip *oldest_tcp;
-    while(!open_flows.empty()) {
-        oldest_tcp = *open_flows.begin();
-        oldest_tcp->close_file();
-      }
-    assert(open_flows.empty());	// we've closed them all
-}
-
-
 /**
  * find the flow that has been written to in the furthest past and close it.
  */

--- a/src/tcpdemux.h
+++ b/src/tcpdemux.h
@@ -150,7 +150,6 @@ public:
     void  post_process(tcpip *tcp);    // just before closing; writes XML and closes fd
 
     /* management of open fds and in-process tcpip flows*/
-    void  close_all_fd();
     void  close_tcpip_fd(tcpip *);         
     void  close_oldest_fd();
     void  remove_flow(const flow_addr &flow); // remove a flow from the database, closing open files if necessary

--- a/src/tcpflow.cpp
+++ b/src/tcpflow.cpp
@@ -737,7 +737,6 @@ int main(int argc, char *argv[])
     int open_fds = (int)demux.open_flows.size();
     int flow_map_size = (int)demux.flow_map.size();
 
-    demux.close_all_fd();
     demux.remove_all_flows();	// empty the map to capture the state
     std::stringstream ss;
     be13::plugin::phase_shutdown(fs,xreport ? &ss : 0);

--- a/src/tcpflow.cpp
+++ b/src/tcpflow.cpp
@@ -750,9 +750,8 @@ int main(int argc, char *argv[])
     DEBUG(2)(total_flow_processed.c_str(),demux.flow_counter);
     DEBUG(2)(total_packets_processed.c_str(),demux.packet_counter);
 
-    if(xreport){
-
 	demux.remove_all_flows();	// empty the map to capture the state
+    if(xreport){
         xreport->pop();                 // fileobjects
         xreport->xmlout("summary",ss.str(),"",false);
         xreport->xmlout("open_fds_at_end",open_fds);

--- a/src/tcpflow.cpp
+++ b/src/tcpflow.cpp
@@ -738,6 +738,7 @@ int main(int argc, char *argv[])
     int flow_map_size = (int)demux.flow_map.size();
 
     demux.close_all_fd();
+    demux.remove_all_flows();	// empty the map to capture the state
     std::stringstream ss;
     be13::plugin::phase_shutdown(fs,xreport ? &ss : 0);
 
@@ -750,7 +751,6 @@ int main(int argc, char *argv[])
     DEBUG(2)(total_flow_processed.c_str(),demux.flow_counter);
     DEBUG(2)(total_packets_processed.c_str(),demux.packet_counter);
 
-	demux.remove_all_flows();	// empty the map to capture the state
     if(xreport){
         xreport->pop();                 // fileobjects
         xreport->xmlout("summary",ss.str(),"",false);


### PR DESCRIPTION
I fixed below bugs about shutdown logic.
- Some flows at the end might be lost if enable_report=NO
- Some redundant close and reopen.
- Plugin process was called from remove_all_flows after plugin is shutdown.