### PR TITLE
Issue #106 - unexpectedly large flow files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "src/http-parser"]
 	path = src/http-parser
-	url = git://github.com/joyent/http-parser.git
+	url = https://github.com/joyent/http-parser.git
 [submodule "src/be13_api"]
 	path = src/be13_api
-	url = git://github.com/simsong/be13_api.git
+	url = https://github.com/simsong/be13_api.git
 [submodule "src/dfxml"]
 	path = src/dfxml
 	url = https://github.com/simsong/dfxml.git

--- a/src/tcpdemux.cpp
+++ b/src/tcpdemux.cpp
@@ -459,6 +459,7 @@ int tcpdemux::process_tcp(const ipaddr &src, const ipaddr &dst,sa_family_t famil
 
 	if(abs(delta) > opt.max_seek){
 	    remove_flow(this_flow);
+	    delta = 0;
 	    tcp = 0;
 	}
     }


### PR DESCRIPTION
The minor change to tcpdemux.cpp should solve the issue of the unexpected large flow files which occurs when ports get reused during processing of a pcap file.

Minor changes were made to the .gitmodules to be consistent in the use of the https:// vs git:// URI.