### PR TITLE
Fix #122: Zombies and leaked fds

### DIFF
--- a/src/tcpflow.cpp
+++ b/src/tcpflow.cpp
@@ -381,6 +381,7 @@ static void process_infile(const std::string &expression,const char *device,cons
     if (pipefd != -1) {
         close (pipefd);
     }
+#endif
 }
 
 


### PR DESCRIPTION
- Call pcap_close so we don't lead /dev/fd/x
- Close pipe fd in parent so we don't leak
