### PR TITLE
Tweak example build commands

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,6 @@
 Better install instructions will go here.
 
-1 - sh bootstrap.sh
-2 - sh configure
+1 - ./bootstrap.sh
+2 - ./configure
 3 - make
 4 - make install


### PR DESCRIPTION
bootstrap.sh will fail on most systems if run with "sh bootstrap.sh"
because it requires Bash and the system shell is usually something
faster. It will succeed if run with "./boostrap.sh" because it specifies
Bash with a shebang.

We might as well change "sh configure" to "./configure" as well because
the latter is more reliable and idiomatic.