### PR TITLE
Fixed broken links in documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ pdft:
 #
 
 RELEASE_USER = simsong@
-RELEASE_HOST = www.digitalcorpora.org
+RELEASE_HOST = digitalcorpora.org
 RELEASE_DIR  = digitalcorpora.org/
 
 RELEASE_LOC  = $(RELEASE_DIR)/downloads/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 TCPFLOW 1.4.6
 ===========
-Downloads directory: http://www.digitalcorpora.org/downloads/tcpflow/
+Downloads directory: http://digitalcorpora.org/downloads/tcpflow/
 
 
 Compiling

--- a/doc/tcpflow.1.in
+++ b/doc/tcpflow.1.in
@@ -383,7 +383,7 @@ Network visualization code by Michael Shick <mike@shick.in>
 .LP
 The current version of this software is available at
 .RS
-.I http://www.digitalcorpora.org/downloads/tcpflow/
+.I http://digitalcorpora.org/downloads/tcpflow/
 .LP
 .RE
 An announcement mailing list for this program is at:


### PR DESCRIPTION
Hello,

I found some broken links in the documentation files (CNAME/A DNS record is missing), so I decided to fix it. 