### PR TITLE
Introduce CMake files (just for IDE and code checking)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(tcpflow VERSION 1.4.6 LANGUAGES CXX C)
+# Within the above line, "C" is required for two reasons:
+# 1. find_package(Threads) fails using only CXX on cmake-3.3 and previous
+# 2. CMake files use CMAKE_C_COMPILER_ID instead of CMAKE_CXX_COMPILER_ID
+
+# find_package(pcap) -> cmake/FindPCAP.cmake
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+
+include(cmake/options.cmake)             # Set default CMake options
+include(cmake/coverage.cmake)            # Configure the build "Coverage"
+include(cmake/compilation-flags.cmake)   # Compiler & Linker flags
+include(cmake/warning-flags.cmake)       # Compiler & Linker warnings
+
+
+
+
+
+# Source code
+add_subdirectory(src)
+
+# Generate documentation
+#add_subdirectory( doc EXCLUDE_FROM_ALL )
+

--- a/cmake/FindPCAP.cmake
+++ b/cmake/FindPCAP.cmake
@@ -1,0 +1,38 @@
+# Tries to find libpcap headers and libraries
+#
+# Usage of this module as follows:
+#
+#     find_package(PCAP)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  PCAP_ROOT_DIR  Set this variable to the root installation of
+#                 libpcap if the module has problems finding
+#                 the proper installation path.
+#
+# Variables defined by this module:
+#
+#  PCAP_FOUND              System has PCAP libs/headers
+#  PCAP_LIBRARIES          The PCAP libraries
+#  PCAP_INCLUDE_DIR        The location of PCAP headers
+
+find_path(PCAP_INCLUDE_DIR
+  NAMES pcap.h
+  HINTS ${PCAP_ROOT_DIR}/include)
+
+find_library(PCAP_LIBRARIES
+  NAMES pcap
+  HINTS ${PCAP_ROOT_DIR}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  PCAP
+  DEFAULT_MSG
+  PCAP_LIBRARIES
+  PCAP_INCLUDE_DIR)
+
+mark_as_advanced(
+  PCAP_ROOT_DIR
+  PCAP_LIBRARIES
+  PCAP_INCLUDE_DIR)

--- a/cmake/compilation-flags.cmake
+++ b/cmake/compilation-flags.cmake
@@ -1,0 +1,85 @@
+# This files sets the compiler/linker flags
+# Supported compilers: GCC and Clang
+
+if(NOT CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(STATUS "<compilation-flags.cmake> No flag set for your compiler '${CMAKE_CXX_COMPILER_ID}' (only GNU and Clang are supported for the moment)")
+    return()
+endif()
+
+# -g3 => Max debug info for all targets (for any CMAKE_BUILD_TYPE)
+# Replace -g3 by -g2 if produced binaries are too big
+# Binaries may also be stripped to remove all debug info
+add_compile_options(-g3) # -g3 -> include also the MACRO definitions
+
+# Use distcc/ccache if available
+# TODO(olibre): Use "CMAKE_{C,CXX}_COMPILER_LAUNCHER=ccache" with cmake-v3.4
+find_program(path_distcc distcc)
+find_program(path_ccache ccache)
+if(path_ccache AND path_distcc)
+    message(STATUS "<compilation-flags.cmake> Commands 'distcc' and 'ccache' detected => Use 'distcc' and 'ccache' to speed up build" )
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "env CCACHE_PREFIX=distcc")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    "env CCACHE_PREFIX=distcc")
+elseif(path_ccache)
+    message(STATUS "<compilation-flags.cmake> Command 'ccache' detected => Use 'ccache' to speed up compilation and link" )
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    ccache)
+elseif(path_distcc)
+    message(STATUS "<compilation-flags.cmake> Command 'distcc' detected => Use 'distcc' to speed up compilation and link" )
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE distcc)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    distcc)
+endif()
+
+# Compilation flag -march
+if(MARCH STREQUAL "native")
+    if(CMAKE_COMPILER_IS_GNUCXX)
+        EXECUTE_PROCESS( COMMAND ${CMAKE_CXX_COMPILER} -march=native -Q --help=target COMMAND awk "/-march=/{ printf $2}" OUTPUT_VARIABLE march_native )
+        message(STATUS "<compilation-flags.cmake> MARCH is native and compiler is GNU => Detected processor '${march_native}' => -march=${march_native}")
+        add_compile_options( -march=${march_native} )
+    else()
+        message(STATUS "<compilation-flags.cmake> MARCH is native and compiler is *not* GNU => -march=native")
+        add_compile_options( -march=native )
+    endif()
+elseif( MARCH )
+    message(STATUS "<compilation-flags.cmake> MARCH is not native => -march=${MARCH}")
+    add_compile_options( -march=${MARCH} )
+else()
+    message(STATUS "<compilation-flags.cmake> MARCH is empty => Do not set flag -march")
+endif()
+
+
+#  # Speed up build using pipes (rather than temporary files) for communication between the various GCC stages
+#  add_compile_options(-pipe)
+#  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pipe")
+#  TODO(olibre): Command link_libraries(-pipe) may be use instead of above line (why not?)
+
+
+
+# Optimization flag
+# Set -O0/-Og/-O1/-O2/-O3/-Ofast depending on CMAKE_BUILD_TYPE
+if(OPTIM STREQUAL "default")
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        message(STATUS "<compilation-flags.cmake> OPTIM=${OPTIM} and CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} => -02")
+        add_compile_options(-O2)
+    else()
+        message(STATUS "<compilation-flags.cmake> OPTIM=${OPTIM} and CMAKE_BUILD_TYPE!='Release' => -O0 -fno-inline")
+        add_compile_options(-O0 -fno-inline)
+    endif()
+elseif(OPTIM)
+    message(STATUS "<compilation-flags.cmake> OPTIM!='default' => Add content of OPTIM=${OPTIM} in compiler flags")
+    add_compile_options(${OPTIM})
+endif()
+
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(STATUS "<compilation-flags.cmake> CMAKE_BUILD_TYPE='${CMAKE_BUILD_TYPE}' => Add -D_GLIBCXX_DEBUG_PEDANTIC in compiler flags")
+    add_definitions(-D_GLIBCXX_DEBUG_PEDANTIC)
+endif()
+
+# Instrument the produced libraries/executables for run-time analysis
+if(SANITIZE STREQUAL "multi")
+    message(STATUS "<compilation-flags.cmake> Detected SANITIZE='${SANITIZE}' => Add '-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=signed-integer-overflow -fsanitize=shift -fsanitize=integer-divide-by-zero -fsanitize=null' in compiler flags")
+    add_compile_options(-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=signed-integer-overflow -fsanitize=shift -fsanitize=integer-divide-by-zero -fsanitize=null)
+elseif(SANITIZE)
+    message(STATUS "<compilation-flags.cmake> Detected SANITIZE is enable but not 'multi' => Add '-fsanitize=${SANITIZE}' in compiler flags")
+    add_compile_options(-fsanitize=${SANITIZE})
+endif()

--- a/cmake/compilation-flags.cmake
+++ b/cmake/compilation-flags.cmake
@@ -1,15 +1,6 @@
 # This files sets the compiler/linker flags
 # Supported compilers: GCC and Clang
 
-if(NOT CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    message(STATUS "<compilation-flags.cmake> No flag set for your compiler '${CMAKE_CXX_COMPILER_ID}' (only GNU and Clang are supported for the moment)")
-    return()
-endif()
-
-# -g3 => Max debug info for all targets (for any CMAKE_BUILD_TYPE)
-# Replace -g3 by -g2 if produced binaries are too big
-# Binaries may also be stripped to remove all debug info
-add_compile_options(-g3) # -g3 -> include also the MACRO definitions
 
 # Use distcc/ccache if available
 # TODO(olibre): Use "CMAKE_{C,CXX}_COMPILER_LAUNCHER=ccache" with cmake-v3.4
@@ -20,14 +11,34 @@ if(path_ccache AND path_distcc)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "env CCACHE_PREFIX=distcc")
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    "env CCACHE_PREFIX=distcc")
 elseif(path_ccache)
-    message(STATUS "<compilation-flags.cmake> Command 'ccache' detected => Use 'ccache' to speed up compilation and link" )
+    message(STATUS "<compilation-flags.cmake> Command 'ccache' detected => Use 'ccache' to speed up compilation and link")
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    ccache)
 elseif(path_distcc)
-    message(STATUS "<compilation-flags.cmake> Command 'distcc' detected => Use 'distcc' to speed up compilation and link" )
+    message(STATUS "<compilation-flags.cmake> Command 'distcc' detected => Use 'distcc' to speed up compilation and link")
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE distcc)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    distcc)
 endif()
+
+
+if(NOT CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(STATUS "<compilation-flags.cmake> Rest of compiler/linker flags are not available for your C++ compiler '${CMAKE_CXX_COMPILER_ID}' (only GNU and Clang are supported for the moment, please help extend these flags for your tools)")
+    return()
+endif()
+
+
+if (BUILD_COLOR)
+    message(STATUS "<compilation-flags.cmake> Detected defined BUILD_COLOR => Use -fdiagnostics-color=${BUILD_COLOR}")
+    add_compile_options (-fdiagnostics-color=${BUILD_COLOR})
+    link_libraries      (-fdiagnostics-color=${BUILD_COLOR})
+endif()
+
+
+# -g3 => Max debug info for all targets (for any CMAKE_BUILD_TYPE)
+# Replace -g3 by -g2 if produced binaries are too big
+# Binaries may also be stripped (at packaging stage) to remove debug info
+add_compile_options(-g3) # -g3 -> include also the MACRO definitions
+
 
 # Compilation flag -march
 if(MARCH STREQUAL "native")

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -1,0 +1,77 @@
+# Configuraion of the Coverage build
+# Also adds targets to generate coverage repports
+
+# Process this file only if BUILD_TYPE is "Coverage"
+if( NOT CMAKE_BUILD_TYPE STREQUAL "Coverage" )
+    return()
+endif()
+
+# This file support coverage only for GCC and Clang compilers
+if( NOT CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
+    message(WARNING "<coverage.cmake> Coverage not yet implemented for your compiler '${CMAKE_CXX_COMPILER_ID}' (only GNU and Clang)")
+    return()
+endif()
+
+# The function assert() may introduce a bias in covered lines count
+# To ignore lines about assert() => Disable assert() 
+add_definitions(-DNDEBUG)
+
+# Compilers GCC and Clang need flag --coverage
+# Flag --coverage is a synonym for -fprofile-arcs -ftest-coverage (when compiling) and -lgcov (when linking)
+# See https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-g_t_0040command_007bgcov_007d-938
+add_compile_options( --coverage )
+link_libraries(      --coverage )
+
+# Depending on presence of tools gcov/gcovr/lcov/genhtml => Add targets
+# HTML report: 
+# - gcovr --root . --html --html-details --output coverage.html --exclude-unreachable-branches --print-summary
+# - lcov + genhtml
+
+find_program (gcov gcov)
+if (NOT gcov)
+    message(WARNING "<coverage.cmake> Cannot find gcov => Build may fail...")
+endif()
+
+find_program (gcovr gcovr)
+if (gcovr)
+    message (STATUS "<coverage.cmake> Found command 'gcovr' => Use target 'gcovr' to generate coverage report '${CMAKE_BINARY_DIR}/gcovr.html'")
+    add_custom_target (gcovr
+        COMMAND ${gcovr} --root             ${CMAKE_SOURCE_DIR}
+                         --exclude          ${CMAKE_SOURCE_DIR}/3rdparty
+                         --exclude          ${CMAKE_BINARY_DIR}
+                         --object-directory ${CMAKE_BINARY_DIR}
+                         --output           ${CMAKE_BINARY_DIR}/gcovr.html
+                         --html
+                         --html-details
+                         --sort-uncovered
+                         --print-summary
+                         --exclude-unreachable-branches
+        COMMAND echo "<coverage.cmake> To display coverage report: firefox ${CMAKE_BINARY_DIR}/gcovr.html"
+    )
+else()
+    message(WARNING "<coverage.cmake> Cannot find command 'gcovr' => Please install package 'gcovr' to generate code coverage report (HTML)")
+endif()
+
+find_program (lcov    lcov   )
+find_program (genhtml genhtml)
+if (lcov AND genhtml)
+    message (STATUS "<coverage.cmake> Found commands 'lcov' and 'genhtml' => Use target 'lcov' to generate coverage report '${CMAKE_BINARY_DIR}/lcov/index.html'")
+    add_custom_target (lcov
+        COMMAND ${lcov}    --capture     --directory     ${CMAKE_BINARY_DIR}
+                           --no-external --output-file   ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-all.info
+                           --no-checksum --base-directory ${CMAKE_SOURCE_DIR}
+                           --rc    lcov_branch_coverage=1 --quiet
+        COMMAND ${lcov}    --remove ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-all.info
+                                            ${CMAKE_SOURCE_DIR}/*/test/*
+                                            ${CMAKE_SOURCE_DIR}/*/*/test/*
+                                            ${CMAKE_SOURCE_DIR}/*/*/*/test/*
+                           --rc    lcov_branch_coverage=1
+                           --output-file   ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.info
+        COMMAND ${genhtml} --rc genhtml_branch_coverage=1 ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.info
+                           --output-directory             ${CMAKE_BINARY_DIR}/lcov
+                           --highlight --legend --quiet
+        COMMAND echo "<coverage.cmake> To display coverage report: firefox ${CMAKE_BINARY_DIR}/lcov/index.html"
+    )
+else()
+    message(WARNING "<coverage.cmake> Cannot find both commands 'lcov' and 'genhtml' => Please install package 'lcov' to generate code coverage report (HTML)")
+endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,14 +1,18 @@
 # Default options and popular parameters
 
-## CMAKE_BUILD_TYPE ##
-# * Release (default) = -O2 + disable assert (-DNDEBUG)
-# * Debug             = -O0 + enable  assert
-# * Coverage          = -O0 + disable assert (-DNDEBUG)
+
+# --------- CMAKE_BUILD_TYPE ----------
+# * Release  = -O2 + disable assert (-DNDEBUG)
+# * Debug    = -O0 + enable  assert              <-- Default value
+# * Coverage = -O0 + disable assert (-DNDEBUG)
+set(CMAKE_CONFIGURATION_TYPES Release Debug Coverage CACHE STRING "Reset the supported CMAKE_BUILD_TYPEs." FORCE)
+# Use "cmake -DCMAKE_BUILD_TYPE=Release" or "cmake -DCMAKE_BUILD_TYPE=Coverage" to override default value 'Debug' 
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "Coverage") # For 'cmake -i' and 'cmake-gui'
-    message(STATUS "<options.cmake> CMAKE_BUILD_TYPE not set => Use value '${CMAKE_BUILD_TYPE}'.")
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "Coverage")
+    message(STATUS "<options.cmake> CMAKE_BUILD_TYPE not set => Use default value '${CMAKE_BUILD_TYPE}'.")
 endif()
+
 
 # Use "cmake -DSANITIZE=address" to enable Address sanitizer
 # Use "cmake -DSANITIZE=thread"  to enable Thread  sanitizer
@@ -16,20 +20,19 @@ endif()
 # Use "cmake -DSANITIZE=dataflow" for DataFlowSanitizer
 # Use "cmake -DSANITIZE=cfi" for control flow integrity checks (requires -flto)
 # Use "cmake -DSANITIZE=safe-stack" for safe stack protection against stack-based memory corruption errors.
+# Use "cmake -DSANITIZE=multi" to combine some of them
 if(NOT SANITIZE)
     set(SANITIZE "OFF" CACHE STRING "Enable Address/Thread/Memory sanitizer.")
     set_property(CACHE SANITIZE PROPERTY STRINGS "OFF" "address" "thread" "memory" "dataflow" "cfi" "safe-stack" "multi")
-    message(STATUS "<options.cmake> No SANITIZE (argument -DSANITIZE) => Set default value SANITIZE='${SANITIZE}'")
+    message(STATUS "<options.cmake> SANITIZE not set (cmake -DSANITIZE=xxx) => Set default value SANITIZE='${SANITIZE}'")
 endif()
 #option(SANITIZE "Sanity check" OFF)
 
-# Use "cmake -DMARCH=native" to detect your current cpu-type 'xxx' and use it as -march=xxx
-# Use another "-DMARCH=xxxx" to set a specific flag -march=xxx
-# Default is "-DMARCH=corei7" on x86 architecture
+# Use "cmake -DMARCH=native" to detect your current cpu-type 'xxx' and CMake will convert to -march=xxx
+# Use "cmake -DMARCH=zzzz" to set a specific flag -march=zzzz
+# Default is "-DMARCH=corei7" (fine on x86 architecture)
+# Use "cmake -DMARCH=   " (empty value) to disable flag -march
 set(MARCH "corei7" CACHE STRING "Control flag -march")
-# Default produce -march=corei7
-# To override use for example:    cmake .. -DMARCH=native (if native => convert to real )
-# To disable provide empty value: cmake .. -DMARCH=
 
 # Control flags -O0 -O1 -O2 -O3 -Ofast -Os -Og
 set(OPTIM "" CACHE STRING "Control flags -Ox")
@@ -37,21 +40,22 @@ set(OPTIM "" CACHE STRING "Control flags -Ox")
 # For clang-check
 set(CMAKE_EXPORT_COMPILE_COMMANDS "on")
 
-# For user tooling (ex: YouCompleteMe)
-#TODO FIXME configure_file(${CMAKE_CURRENT_LIST_DIR}/templates/BuildConfig.json.in ${RootDistDir}/dist/${SubDistDir}/BuildConfig.json)
 
 # Colorize output: "always" or "auto" ("auto" colorizes if output is TTY)
 if (ENV{BUILD_COLOR})
-    option(BUILD_COLOR "Enable colored output for make and compiler" $ENV{BUILD_COLOR})
+    option(BUILD_COLOR "<options.cmake> Enable colored output for make and compiler" $ENV{BUILD_COLOR})
 else()
-    option(BUILD_COLOR "Enable colored output for make and compiler" always)
+    option(BUILD_COLOR "<options.cmake> Enable colored output for make and compiler" always)
 endif()
 
-if (BUILD_COLOR)
-    add_compile_options (-fdiagnostics-color=${BUILD_COLOR})
-endif()
 
 # Static code analysis
-# Below line will enable the file 'compile_commands.json' to be used with clang-check
-# Usage: awk -F: '/"file"/{print $2 }' build/compile_commands.json | xargs clang-check -fixit -p build
+# Below line is to generate the file 'compile_commands.json' during the build
+# Then, the file 'compile_commands.json' can be used with clang-check using the below command line:
+# awk -F: '/"file"/{print $2 }' build/compile_commands.json | xargs clang-check -fixit -p build
 set(CMAKE_EXPORT_COMPILE_COMMANDS "on")
+
+
+# For Tools like YouCompleteMe
+# TODO(???): Provide BuildConfig.json.in
+# configure_file(${CMAKE_CURRENT_LIST_DIR}/templates/BuildConfig.json.in ${CMAKE_CURRENT_BINARY_DIR}/BuildConfig.json)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,0 +1,57 @@
+# Default options and popular parameters
+
+## CMAKE_BUILD_TYPE ##
+# * Release (default) = -O2 + disable assert (-DNDEBUG)
+# * Debug             = -O0 + enable  assert
+# * Coverage          = -O0 + disable assert (-DNDEBUG)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "Coverage") # For 'cmake -i' and 'cmake-gui'
+    message(STATUS "<options.cmake> CMAKE_BUILD_TYPE not set => Use value '${CMAKE_BUILD_TYPE}'.")
+endif()
+
+# Use "cmake -DSANITIZE=address" to enable Address sanitizer
+# Use "cmake -DSANITIZE=thread"  to enable Thread  sanitizer
+# Use "cmake -DSANITIZE=memory"  to enable Memory  sanitizer
+# Use "cmake -DSANITIZE=dataflow" for DataFlowSanitizer
+# Use "cmake -DSANITIZE=cfi" for control flow integrity checks (requires -flto)
+# Use "cmake -DSANITIZE=safe-stack" for safe stack protection against stack-based memory corruption errors.
+if(NOT SANITIZE)
+    set(SANITIZE "OFF" CACHE STRING "Enable Address/Thread/Memory sanitizer.")
+    set_property(CACHE SANITIZE PROPERTY STRINGS "OFF" "address" "thread" "memory" "dataflow" "cfi" "safe-stack" "multi")
+    message(STATUS "<options.cmake> No SANITIZE (argument -DSANITIZE) => Set default value SANITIZE='${SANITIZE}'")
+endif()
+#option(SANITIZE "Sanity check" OFF)
+
+# Use "cmake -DMARCH=native" to detect your current cpu-type 'xxx' and use it as -march=xxx
+# Use another "-DMARCH=xxxx" to set a specific flag -march=xxx
+# Default is "-DMARCH=corei7" on x86 architecture
+set(MARCH "corei7" CACHE STRING "Control flag -march")
+# Default produce -march=corei7
+# To override use for example:    cmake .. -DMARCH=native (if native => convert to real )
+# To disable provide empty value: cmake .. -DMARCH=
+
+# Control flags -O0 -O1 -O2 -O3 -Ofast -Os -Og
+set(OPTIM "" CACHE STRING "Control flags -Ox")
+
+# For clang-check
+set(CMAKE_EXPORT_COMPILE_COMMANDS "on")
+
+# For user tooling (ex: YouCompleteMe)
+#TODO FIXME configure_file(${CMAKE_CURRENT_LIST_DIR}/templates/BuildConfig.json.in ${RootDistDir}/dist/${SubDistDir}/BuildConfig.json)
+
+# Colorize output: "always" or "auto" ("auto" colorizes if output is TTY)
+if (ENV{BUILD_COLOR})
+    option(BUILD_COLOR "Enable colored output for make and compiler" $ENV{BUILD_COLOR})
+else()
+    option(BUILD_COLOR "Enable colored output for make and compiler" always)
+endif()
+
+if (BUILD_COLOR)
+    add_compile_options (-fdiagnostics-color=${BUILD_COLOR})
+endif()
+
+# Static code analysis
+# Below line will enable the file 'compile_commands.json' to be used with clang-check
+# Usage: awk -F: '/"file"/{print $2 }' build/compile_commands.json | xargs clang-check -fixit -p build
+set(CMAKE_EXPORT_COMPILE_COMMANDS "on")

--- a/cmake/warning-flags.cmake
+++ b/cmake/warning-flags.cmake
@@ -1,0 +1,107 @@
+# Warning flags and Macro (#define)
+
+
+# For the moment only support GCC and Clang
+if(NOT CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(STATUS "<warning-flags.cmake> No warning set for your compiler '${CMAKE_CXX_COMPILER_ID}' (only GNU and Clang are supported for the moment)")
+    return()
+endif()
+
+
+# See http://stackoverflow.com/a/16604146/938111
+add_definitions(-D_FORTIFY_SOURCE=2)
+
+
+# Colorize output
+if (BUILD_COLOR)
+    add_compile_options(-fdiagnostics-color=${BUILD_COLOR})
+endif()
+
+# Clang specifics
+if (CMAKE_C_COMPILER_ID STREQUAL Clang)
+    add_compile_options(
+        -Weverything
+        -Wno-c++98-compat
+        -Wno-c++98-compat-pedantic
+    )
+endif()
+
+add_compile_options(
+    -Wall                        # Classic warnings
+    -Wextra                      # Extra amount of warnings
+    -Weffc++                     # Books "Effective C++" from Scott Meyers
+    -pedantic                    # Reject code not following ISO C++ (e.g. GNU extensions)
+    -Winit-self                  # Variables initialized with themselves (enabled by -Wall)
+    -Wswitch-enum                # Missing case for values of switch(enum)
+    -Wswitch                     # Missing enumerated type in 'case' labels
+    -Wcast-align                 # Incompatible alignment pointers
+    -Wcast-qual                  # Cast between pointers leads to target type qualifier removal
+    -Wconversion                 # Conversion might lead to value alteration, confusing overload resolution
+    -Wsign-conversion
+    -Wformat=2                   # Invalid argument types and format strings in formatting functions (printf, scanf...)
+    -Wuninitialized              # Variable used without being initialized
+    -Wmissing-field-initializers # Fields is left uninitialized during (non-designated) structure initialization
+    -Wmissing-include-dirs       # User-supplied include directory does not exist
+    -Wpointer-arith              # [void and function] Operations addition/subtraction/sizeof are GNU extension
+    -Wredundant-decls            # Multiple declarations of the same entity is encountered in the same scope
+    -Wshadow                     # Variable/typedef/struct/class/enum shadows another one having same name
+    -Wunreachable-code           # Unreachable code
+    -Wunused                     # Unused entity (functions, labels, variables, typedefs, parameters, ...)
+    -Wwrite-strings              # Deprecated conversion from string literals to 'char *' (enable by default in C++)
+    -fmax-errors=50              # Limit number of errors to 50. Default is 0 => no limit
+    -fstack-protector-strong     # Checks for buffer overflows such as stack smashing attacks (extra code is added)
+    -Wstack-protector            # Warn if option '-fstack-protector-strong' complained about codes vulnerable to stack smashing
+
+    -Wpointer-arith
+    -Wshadow
+    -Wwrite-strings
+    -Wcast-align
+    -Wredundant-decls
+    -Wdisabled-optimization
+    -Wfloat-equal
+    -Wmultichar
+    -Wmissing-noreturn
+    -Woverloaded-virtual
+    -Wsign-promo
+    -funit-at-a-time
+    -Weffc++
+    -Wall
+    -Wpointer-arith
+    -Wshadow
+    -Wwrite-strings
+    -Wcast-align
+    -Wredundant-decls
+    -Wdisabled-optimization
+    -Wfloat-equal
+    -Wmultichar
+    -Wmissing-noreturn
+    -Woverloaded-virtual
+    -Wsign-promo
+    -funit-at-a-time
+    -Wstrict-null-sentinel
+    -Wswitch-enum
+    -Wpadded
+    -Wfloat-conversion
+    -Wunused-macros
+    -Wshadow
+    -Wmissing-prototypes
+)
+
+# Temporary disable some warnings because too much warnings :-(
+add_compile_options(
+    -Wno-sign-conversion    # 1125 warnings (GCC-6)
+    -Wno-padded             #  650 warnings (GCC-6)
+    -Wno-unused-parameter   #  577 warnings (GCC-6)
+    -Wno-pedantic           #  326 warnings (GCC-6)
+    -Wno-cast-qual          #  211 warnings (GCC-6)
+    -Wno-conversion         #  123 warnings (GCC-6)
+    -Wno-switch-enum        #  111 warnings (GCC-6)
+
+    -Wno-old-style-cast     # 1679 warnings (Clang-3.9)
+    -Wno-extra-semi         #  490 warnings (Clang-3.9)
+    -Wno-weak-vtables       #  325 warnings (Clang-3.9)
+    -Wno-packed             #  304 warnings (Clang-3.9)
+    -Wno-documentation      #  187 warnings (Clang-3.9)
+    -Wno-reserved-id-macro  #  138 warnings (Clang-3.9)
+    -Wno-deprecated         #  123 warnings (Clang-3.9)
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,190 @@
+set(CMAKE_CXX_STANDARD 11)
+
+# System Dependencies
+find_package(Boost) #TODO(olibre): COMPONENTS program_options system)
+find_package(PCAP)
+find_package(OpenSSL)
+find_package(Threads)
+
+
+# TODO(olibre): Use target_link_libraries() instead of include_directories()
+include_directories(.)
+
+
+# TODO(olibre): Fix detection of below headers
+include (CheckIncludeFiles)
+# Below lines have been produced using this command line
+# sed 's|/\* ||' config.h | awk '$1 ~ /#undef|#define/{print $2}' | sort -u | while read w ; do grep -wB1 $w config.h | grep '[^ ]*> header' | sed "s/.*</check_include_files(/;s/>//;s/header.*/$w)/"; done
+check_include_files(arpa/inet.h HAVE_ARPA_INET_H)
+check_include_files(boost/icl/interval.hpp HAVE_BOOST_ICL_INTERVAL_HPP)
+check_include_files(boost/icl/interval_map.hpp HAVE_BOOST_ICL_INTERVAL_MAP_HPP)
+check_include_files(boost/icl/interval_set.hpp HAVE_BOOST_ICL_INTERVAL_SET_HPP)
+check_include_files(boost/version.hpp HAVE_BOOST_VERSION_HPP)
+check_include_files(cairo/cairo.h HAVE_CAIRO_CAIRO_H)
+check_include_files(cairo/cairo-pdf.h HAVE_CAIRO_CAIRO_PDF_H)
+check_include_files(cairo.h HAVE_CAIRO_H)
+check_include_files(cairo-pdf.h HAVE_CAIRO_PDF_H)
+check_include_files(ctype.h HAVE_CTYPE_H)
+check_include_files(err.h HAVE_ERR_H)
+check_include_files(exiv2/image.hpp HAVE_EXIV2_IMAGE_HPP)
+check_include_files(expat.h HAVE_EXPAT_H)
+check_include_files(fcntl.h HAVE_FCNTL_H)
+check_include_files(inttypes.h HAVE_INTTYPES_H)
+check_include_files(linux/if_ether.h HAVE_LINUX_IF_ETHER_H)
+check_include_files(memory.h HAVE_MEMORY_H)
+check_include_files(net/ethernet.h HAVE_NET_ETHERNET_H)
+check_include_files(net/if.h HAVE_NET_IF_H)
+check_include_files(net/if_var.h HAVE_NET_IF_VAR_H)
+check_include_files(netinet/in.h HAVE_NETINET_IN_H)
+check_include_files(netinet/in_systm.h HAVE_NETINET_IN_SYSTM_H)
+check_include_files(netinet/ip_ether.h HAVE_NETINET_IP_ETHER_H)
+check_include_files(netinet/ip.h HAVE_NETINET_IP_H)
+check_include_files(netinet/ip_var.h HAVE_NETINET_IP_VAR_H)
+check_include_files(netinet/tcp.h HAVE_NETINET_TCP_H)
+check_include_files(netinet/tcpip.h HAVE_NETINET_TCPIP_H)
+check_include_files(openssl/aes.h HAVE_OPENSSL_AES_H)
+check_include_files(openssl/bio.h HAVE_OPENSSL_BIO_H)
+check_include_files(openssl/evp.h HAVE_OPENSSL_EVP_H)
+check_include_files(openssl/hmac.h HAVE_OPENSSL_HMAC_H)
+check_include_files(openssl/md5.h HAVE_OPENSSL_MD5_H)
+check_include_files(openssl/pem.h HAVE_OPENSSL_PEM_H)
+check_include_files(openssl/rand.h HAVE_OPENSSL_RAND_H)
+check_include_files(openssl/rsa.h HAVE_OPENSSL_RSA_H)
+check_include_files(openssl/sha.h HAVE_OPENSSL_SHA_H)
+check_include_files(openssl/x509.h HAVE_OPENSSL_X509_H)
+check_include_files(pcap.h HAVE_PCAP_H)
+check_include_files(pcap/pcap.h HAVE_PCAP_PCAP_H)
+check_include_files(pthread.h HAVE_PTHREAD_H)
+check_include_files(pwd.h HAVE_PWD_H)
+check_include_files(regex.h HAVE_REGEX_H)
+check_include_files(semaphore.h HAVE_SEMAPHORE_H)
+check_include_files(signal.h HAVE_SIGNAL_H)
+check_include_files(sqlite3.h HAVE_SQLITE3_H)
+check_include_files(stdint.h HAVE_STDINT_H)
+check_include_files(stdio.h HAVE_STDIO_H)
+check_include_files(stdlib.h HAVE_STDLIB_H)
+check_include_files(string HAVE_STRING)
+check_include_files(string.h HAVE_STRING_H)
+check_include_files(strings.h HAVE_STRINGS_H)
+check_include_files(sys/bitypes.h HAVE_SYS_BITYPES_H)
+check_include_files(sys/cdefs.h HAVE_SYS_CDEFS_H)
+check_include_files(syslog.h HAVE_SYSLOG_H)
+check_include_files(sys/mman.h HAVE_SYS_MMAN_H)
+check_include_files(sys/resource.h HAVE_SYS_RESOURCE_H)
+check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
+check_include_files(sys/stat.h HAVE_SYS_STAT_H)
+check_include_files(sys/types.h HAVE_SYS_TYPES_H)
+check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
+check_include_files(sys/wait.h HAVE_SYS_WAIT_H)
+check_include_files(tr1/unordered_map HAVE_TR1_UNORDERED_MAP)
+check_include_files(tr1/unordered_set HAVE_TR1_UNORDERED_SET)
+check_include_files(tre/tre.h HAVE_TRE_TRE_H)
+check_include_files(unistd.h HAVE_UNISTD_H)
+check_include_files(unordered_map HAVE_UNORDERED_MAP)
+check_include_files(unordered_set HAVE_UNORDERED_SET)
+check_include_files(winsock2.h HAVE_WINSOCK2_H)
+check_include_files(zlib.h HAVE_ZLIB_H)
+# The following command lines list the rest of the #define that are used but not yet implemented using CMake directives
+# sed 's|/\* ||' config.h | awk '$1 ~ /#undef|#define/{print $2}' | sort -u | while read w ; do grep -wB1 $w config.h | grep '[^ ]*> header' -q && echo $w; done > already-implemented-using-cmake-directives
+# ( sed 's|/\* ||' config.h | awk '$1 ~ /#undef|#define/{print $2}'  | sort -u | while read w ; do find src -name 'config.h' -o -regex '.*.h\|.*.cpp' -exec fgrep -Iowqm1 $w {} '+' && echo "$w" ; done ) > used-in-source-code
+# comm -13 already-implemented-using-cmake-directives used-in-source-code | grep -wf - config.h -B1 --color=always > rest-to-implement-using-cmake-directives
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
+# When all #define from config.h are implemented using CMake directives the following line...
+include_directories(..)                            #include the <config.h> generated by autotools
+# ...by this one:
+# include_directories(${CMAKE_CURRENT_BINARY_DIR}) #include the <config.h> generated by CMake
+
+
+
+file (GLOB netviz_cpp netviz/*.cpp)
+file (GLOB netviz_h   netviz/*.h)
+source_group("netviz headers" FILES ${netviz_h})
+add_library (netviz  ${netviz_cpp}  ${netviz_h})
+target_include_directories(netviz PUBLIC netviz)
+
+# add_subdirectory(dfxml/src)
+set(dfxml_writer_h dfxml/src/dfxml_writer.h dfxml/src/hash_t.h)
+source_group("dfxml_writer headers" FILES ${dfxml_writer_h})
+add_library (dfxml_writer dfxml/src/dfxml_writer.cpp ${dfxml_writer_h})
+target_link_libraries(dfxml_writer OpenSSL::SSL)
+target_include_directories(dfxml_writer PUBLIC dfxml/src)
+
+#file (GLOB wifipcap_glob_cpp wifipcap/*.cpp)
+#file (GLOB wifipcap_glob_h   wifipcap/*.h)
+#set (wifipcap_cpp datalink_wifi.cpp ${wifipcap_glob_cpp} )
+#set (wifipcap_h   datalink_wifi.h   ${wifipcap_glob_h} )
+set (wifipcap_cpp
+    datalink_wifi.cpp
+    scan_wifiviz.cpp
+    wifipcap/TimeVal.cpp
+    wifipcap/cpack.cpp
+    wifipcap/wifipcap.cpp
+    )
+set (wifipcap_h
+    datalink_wifi.h
+    wifipcap/TimeVal.h
+    wifipcap/arp.h
+    wifipcap/cpack.h
+    wifipcap/ether.h
+    wifipcap/ethertype.h
+    wifipcap/extract.h
+    wifipcap/icmp.h
+    wifipcap/ieee802_11_radio.h
+    wifipcap/ip.h
+    wifipcap/ip6.h
+    wifipcap/ipproto.h
+    wifipcap/llc.h
+    wifipcap/os.h
+    wifipcap/oui.h
+    wifipcap/prism.h
+    wifipcap/radiotap.h
+    wifipcap/tcp.h
+    wifipcap/types.h
+    wifipcap/udp.h
+    wifipcap/util.h
+    wifipcap/wifipcap.h
+    )
+source_group("wifipcap headers" FILES ${wifipcap_h})
+add_library (wifipcap ${wifipcap_cpp} ${wifipcap_h})
+target_link_libraries(wifipcap dfxml_writer)
+target_include_directories(wifipcap PUBLIC wifipcap be13_api pcap)  # TODO(olibre): Should not depend on be13_api
+
+# add_subdirectory(http-parser)
+source_group("http-parser headers" FILES http-parser/http_parser.h)
+add_library (http-parser
+    http-parser/http_parser.h
+    http-parser/http_parser.c
+)
+
+# add_subdirectory(be13_api)
+file (GLOB_RECURSE be13_api_h   be13_api/*.h)
+file (GLOB         be13_api_cpp be13_api/*.cpp)
+source_group("be13_api headers" FILES ${be13_api_h})
+add_library (be13_api ${be13_api_h} ${be13_api_cpp})
+target_link_libraries(be13_api wifipcap)
+target_include_directories(be13_api PUBLIC be13_api)
+
+set (tcpflow_cpp datalink.cpp flow.cpp
+    tcpflow.cpp
+    tcpip.cpp
+    tcpdemux.cpp
+    util.cpp
+    scan_md5.cpp
+    scan_http.cpp       # Depends on zlib
+    scan_tcpdemux.cpp
+    scan_netviz.cpp
+    pcap_writer.h
+    mime_map.cpp
+)
+set (tcpflow_h
+    iptree.h
+    mime_map.h
+    tcpip.h
+    intrusive_list.h
+    tcpflow.h
+    tcpdemux.h
+)
+source_group("tcpflow headers" FILES ${tcpflow_h})
+add_executable(tcpflow ${tcpflow_cpp} ${tcpflow_h})
+target_link_libraries(tcpflow netviz wifipcap be13_api dfxml_writer http-parser z pcap)


### PR DESCRIPTION
Autotools are still required to generate <config.h>
and to produce full-featured releases.
However the added CMake files provide interresting
facilities for static code checking and sanity.
CMake files will continue to be improved and
may replace autotools...