### PR TITLE
Update very old spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ To Compile for Windows with mingw on Fedora Core:
 
 To use CMake, see detailed instructions: [cmake/README.md](./cmake/README.md)
 
+Build RPM
+---------
+
+From a clean repository as normal user (not root):
+
+    ./bootstrap.sh     # Generates the file ./configure
+    ./configure        # Generates the file tcpflow.spec
+    rpmbuild -bb tcpflow.spec --build-in-place
+
+Check the specfile and resulted RPM:
+
+    rpmlint tcpflow.spec
+    rpmlint ~/rpmbuild/RPMS/x86_64/tcpflow-....rpm
+
+Install:
+
+    sudo dnf install ~/rpmbuild/RPMS/x86_64/tcpflow-....rpm
+
 
 Introduction To tcpflow
 =======================

--- a/tcpflow.spec.in
+++ b/tcpflow.spec.in
@@ -7,7 +7,7 @@ Summary: Network traffic recorder
 Name: tcpflow
 Version: %ver
 Release: %rel
-Copyright: GPLv3
+License: GPLv3
 Group: Console/Networking
 Source: http://afflib.org/downloads/tcpflow-@VERSION@.tar.gz
 BuildRoot: /var/tmp/tcpflow-root
@@ -19,8 +19,8 @@ tcpflow is a program that captures data transmitted as part of TCP connections (
 
 %changelog
 
-* 2012-02-26 Simson Garfinkel <simsong@acm.org> - Rewrite for version 1.2
-* 1999-04-22 Ross Golder <rossigee@bigfoot.com> -  Wrote for version 0.12
+* Sun Feb 26 2012 Simson Garfinkel <simsong@acm.org> - Rewrite for version 1.2
+* Thu Apr 22 1999 Ross Golder <rossigee@bigfoot.com> -  Wrote for version 0.12
 
 %prep
 %setup
@@ -60,5 +60,5 @@ rm -rf $RPM_BUILD_ROOT
 
 %doc AUTHORS COPYING ChangeLog NEWS README
 %{prefix}/bin/*
-%{prefix}/man/man*/*
+%{prefix}/share/man/man*/*
 

--- a/tcpflow.spec.in
+++ b/tcpflow.spec.in
@@ -1,64 +1,57 @@
-# Note that this is NOT a relocatable package
-%define ver      @VERSION@
-%define rel      1
-%define prefix   /usr
+%global _hardened_build 1
 
-Summary: Network traffic recorder
-Name: tcpflow
-Version: %ver
-Release: %rel
-License: GPLv3
-Group: Console/Networking
-Source: http://afflib.org/downloads/tcpflow-@VERSION@.tar.gz
-BuildRoot: /var/tmp/tcpflow-root
-Prefix: %prefix
-URL: http://afflib.org/tcpflow/
+Name:          tcpflow
+Version:       @VERSION@
+Release:       0%{?dist}
+License:       GPLv3
+Summary:       Network traffic recorder
+URL:           https://github.com/simsong/tcpflow
+Source0:       http://digitalcorpora.org/downloads/%{name}/%{name}-%{version}.tar.gz
+
+BuildRequires: boost-devel
+#BuildRequires: bzip2-devel
+BuildRequires: cairo-devel
+BuildRequires: libpcap-devel
+BuildRequires: openssl-devel
+BuildRequires: zlib-devel
 
 %description
-tcpflow is a program that captures data transmitted as part of TCP connections (flows), and stores the data in a way that is convenient for protocol analysis or debugging. A program like 'tcpdump' shows a summary of packets seen on the wire, but usually doesn't store the data that's actually being transmitted. In contrast, tcpflow reconstructs the actual data streams and stores each flow in a separate file for later analysis.
+tcpflow is a program that captures data transmitted as part of TCP
+connections (flows), and stores the data in a way that is convenient
+for protocol analysis or debugging. A program like 'tcpdump' shows a
+summary of packets seen on the wire, but usually doesn't store the
+data that's actually being transmitted. In contrast, tcpflow
+reconstructs the actual data streams and stores each flow in a
+separate file for later analysis.
+
+%prep
+%setup -q
+
+%build
+export CPPFLAGS="%{optflags}"
+export LDFLAGS="%{__global_ldflags}"
+%configure
+make %{?_smp_mflags}
+
+%install
+make DESTDIR=%{buildroot} INSTALL='install -p' install
+
+%check
+#make check
+
+%files
+%doc AUTHORS COPYING ChangeLog NEWS README
+%{_bindir}/tcpflow
+%{_mandir}/man1/tcpflow.1*
 
 %changelog
 
-* Sun Feb 26 2012 Simson Garfinkel <simsong@acm.org> - Rewrite for version 1.2
-* Thu Apr 22 1999 Ross Golder <rossigee@bigfoot.com> -  Wrote for version 0.12
+* Sun Jun 04 2017 O. Libre <olibre@Lmap.org> - 1.4.6-0
+- Apply improvements from Fedora Packages repo https://src.fedoraproject.org/cgit/rpms/?q=tcpflow
 
-%prep
-%setup
+* Sun Feb 26 2012 Simson Garfinkel <simsong@acm.org> - 1.2
+- Rewrite for version 1.2
 
-%build
-# Needed for snapshot releases.
-%ifarch alpha
-  MYARCH_FLAGS="--host=alpha-redhat-linux"
-%endif
-MYCFLAGS="$RPM_OPT_FLAGS"
-
-#if [ ! -f configure ]; then
-#  CFLAGS="$MYCFLAGS" ./autogen.sh $MYARCH_FLAGS --prefix=%prefix --localstatedir=/var/lib --with-pcap=/usr/include/pcap
-#else
-#  CFLAGS="$MYCFLAGS" ./configure $MYARCH_FLAGS --prefix=%prefix --localstatedir=/var/lib --with-pcap=/usr/include/pcap
-#fi
-
-CFLAGS="$MYCFLAGS" ./configure $MYARCH_FLAGS --prefix=%prefix --localstatedir=/var/lib 
-
-if [ "$SMP" != "" ]; then
-  (make "MAKE=make -k -j $SMP"; exit 0)
-  make
-else
-  make
-fi
-
-%install
-rm -rf $RPM_BUILD_ROOT
-
-make prefix=$RPM_BUILD_ROOT%{prefix} install
-
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-%files
-%defattr(-, root, root)
-
-%doc AUTHORS COPYING ChangeLog NEWS README
-%{prefix}/bin/*
-%{prefix}/share/man/man*/*
+* Thu Apr 22 1999 Ross Golder <rossigee@bigfoot.com> - 0.12
+- Wrote for version 0.12
 


### PR DESCRIPTION
Samuel Brown has pushed a commit to fix RPM build on CentOS:
https://github.com/olibre/tcpflow/commit/25b65af75809bb1a9af4f51ee0c21dc3512076a2

By curiosity, I have checked how Fedora manages the tcpflow spec file on its Git repository:
https://src.fedoraproject.org/cgit/rpms/?q=tcpflow

I was to difficult to rebase all the Fedora commits (improvements) to my current branch.
Therefore I compared both spec files and applied most of the Fedora changes.
I have also read the state of the art on specifying & building RPMs:

- https://fedoraproject.org/wiki/Packaging:Guidelines
- https://fedoraproject.org/wiki/Hardened_Packages

The way I have build and checked the RPM is explained in the `README.md`.
Any one can reproduce the same procedure :grinning: 

There are still some issues:

1. Domain name https://digitalcorpora.org/ has a correct SSL certificate.
     However, using HTTPS, the subdomain https://download.digitalcorpora.org is not accessible :disappointed: 
    The HTTP download URL is not considered as enough secure. 
    Moreover, `tcpflow` is downloaded to be run as root on servers having network access :cry: 

2. `rpmlint` does not appreciate the *"dangling relative symlink"* `README` -> `README.md`
