### PR TITLE
Clean shutdown of tcpflow

### DIFF
--- a/src/tcpflow.h
+++ b/src/tcpflow.h
@@ -258,7 +258,7 @@ typedef	unsigned char u_int8_t;
 
 /* tcpflow.cpp - CLI */
 extern const char *progname;
-[[noreturn]] void    terminate(int sig);
+void    terminate(int sig);
 #include "inet_ntop.h"
 
 #ifdef HAVE_PTHREAD


### PR DESCRIPTION
The standard behavior of tcpflow when receiving a terminating signal
(such as SIGINT with Ctrl-C) is to print 'terminating' and do a quick
exit which will not properly close the capture files.

This changes the shutdown logic so that pcap_breakloop(..) is called
in the signal handler for SIGINT and SIGHUP, therefore ensuring a
proper shutdown that closes all files.