### PR TITLE
fix use of pthreads on debian+libevent-pthreads

### DIFF
--- a/src/tcpflow.cpp
+++ b/src/tcpflow.cpp
@@ -766,7 +766,7 @@ int main(int argc, char *argv[])
 
     /* was a semaphore provided for the lock? */
     if(lockname){
-#if defined(HAVE_SEMAPHORE_H) && defined(HAVE_PTHREAD)
+#if defined(HAVE_SEMAPHORE_H) && defined(HAVE_PTHREAD_H)
 	semlock = sem_open(lockname,O_CREAT,0777,1); // get the semaphore
 #else
 	fprintf(stderr,"%s: attempt to create lock pthreads not present\n",argv[0]);


### PR DESCRIPTION
Hello !!

On debian stretch and libevent-pthreads-2.0-5:  
on my build (ldd showed libpthread linked)  
```bash
# tcpflow -L semlockname -i eth1 -o /tmp
(null): attempt to create lock threads not present
```

This PR resolves this issue in my case. Hope this will help.

Fred.