### PR TITLE
Fix build on FreeBSD with GCC

### DIFF
--- a/src/wifipcap/wifipcap.cpp
+++ b/src/wifipcap/wifipcap.cpp
@@ -22,6 +22,9 @@
 #include <errno.h>
 
 #ifdef HAVE_NET_ETHERNET_H
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#endif
 #include <net/ethernet.h>
 #endif
 


### PR DESCRIPTION
This is required for architectures that still use GCC (as opposed to those using Clang).