### PR TITLE
fix coredump problem under non-root user

### DIFF
--- a/src/tcpflow.cpp
+++ b/src/tcpflow.cpp
@@ -469,8 +469,8 @@ static int process_infile(tcpdemux &demux,const std::string &expression,const ch
             die("%s", errbuf);
         }
 
-        if (0 == sizeof(alldevs)/sizeof(pcap_if_t)) {
-            die("found 0 devices, maybe you don't have permissions, switch to root or equivalent user instead");
+        if (alldevs == 0) {
+            die("found 0 devices, maybe you don't have permissions, switch to root or equivalent user instead.");
         }
 
         device=strdup(alldevs[0].name);

--- a/src/tcpflow.cpp
+++ b/src/tcpflow.cpp
@@ -461,21 +461,26 @@ static int process_infile(tcpdemux &demux,const std::string &expression,const ch
 	handler = find_handler(dlt, infile.c_str());
     } else {
 	/* if the user didn't specify a device, try to find a reasonable one */
-	if (device == NULL){
+    if (device == NULL){
 #ifdef HAVE_PCAP_FINDALLDEVS
-            char errbuf[PCAP_ERRBUF_SIZE];
-            pcap_if_t *alldevs = 0;
-            if (pcap_findalldevs(&alldevs,errbuf)){
-		die("%s", errbuf);
-	    }
-            device=strdup(alldevs[0].name);
-            pcap_freealldevs(alldevs);
+        char errbuf[PCAP_ERRBUF_SIZE];
+        pcap_if_t *alldevs = 0;
+        if (pcap_findalldevs(&alldevs,errbuf)){
+            die("%s", errbuf);
+        }
+
+        if (0 == sizeof(alldevs)/sizeof(pcap_if_t)) {
+            die("found 0 devices, maybe you don't have permissions, switch to root or equivalent user instead");
+        }
+
+        device=strdup(alldevs[0].name);
+        pcap_freealldevs(alldevs);
 #else
-	    if ((device = pcap_lookupdev(error)) == NULL){
-		die("%s", error);
-	    }
+        if ((device = pcap_lookupdev(error)) == NULL){
+            die("%s", error);
+        }
 #endif
-	}
+    }
 
 	/* make sure we can open the device */
 	if ((pd = pcap_open_live(device, SNAPLEN, !opt_no_promisc, packet_buffer_timeout, error)) == NULL){


### PR DESCRIPTION
pcap_findalldevs(pcap_if_t **alldevsp, char *errbuf) returns 0 on success and -1 on failure; as indicated, finding no devices is considered success, in this situation, use alldevsp[0] will cause a coredump.