### PR TITLE
Run a command for each saved TCP flow

### DIFF
--- a/src/scan_tcpdemux.cpp
+++ b/src/scan_tcpdemux.cpp
@@ -44,6 +44,8 @@ void  scan_tcpdemux(const class scanner_params &sp,const recursion_control_block
 	sp.info->packet_cb = packet_handler;
         
         sp.info->get_config("tcp_timeout",&tcpdemux::getInstance()->tcp_timeout,"Timeout for TCP connections");
+        sp.info->get_config("tcp_cmd",&tcpdemux::getInstance()->tcp_cmd,"Command to execute on each TCP flow");
+        sp.info->get_config("tcp_alert_fd",&tcpdemux::getInstance()->tcp_alert_fd,"File descriptor to send information about completed TCP flows");
 
         return;     /* No feature files created */
     }

--- a/src/tcpdemux.h
+++ b/src/tcpdemux.h
@@ -86,6 +86,11 @@ class tcpdemux {
 
 public:
     static uint32_t tcp_timeout;
+    static std::string tcp_cmd;                   // command to run on each tcp flow
+    static int tcp_subproc_max;              // how many subprocesses are we allowed?
+    static int tcp_subproc;                   // how many do we currently have?
+    static int tcp_alert_fd; 
+    
     static unsigned int get_max_fds(void);             // returns the max
     virtual ~tcpdemux(){
         delete xreport;


### PR DESCRIPTION
Add support to run a command on each saved TCP flow (tcp_cmd option) and for a TCP alert fd (tcp_alert_fd option).
This is inspired by the http_cmd and http_alert_fd options.