### PR TITLE
Removed out-of-bound accesses

### DIFF
--- a/src/datalink.cpp
+++ b/src/datalink.cpp
@@ -16,6 +16,7 @@
  * For wifi datalink handlers, please see datalink_wifi.cpp
  */
 
+#include <stddef.h>
 #include "tcpflow.h"
 
 /* The DLT_NULL packet header is 4 bytes long. It contains a network

--- a/src/datalink.cpp
+++ b/src/datalink.cpp
@@ -36,7 +36,7 @@ void dl_null(u_char *user, const struct pcap_pkthdr *h, const u_char *p)
 {
     u_int caplen = h->caplen;
     u_int length = h->len;
-    uint32_t family = *(uint32_t *)p;
+    uint32_t family = (uint32_t)*p;
 
     if (length != caplen) {
 	DEBUG(6) ("warning: only captured %d bytes of %d byte null frame",
@@ -86,10 +86,19 @@ void dl_ethernet(u_char *user, const struct pcap_pkthdr *h, const u_char *p)
     u_int caplen = h->caplen;
     u_int length = h->len;
     struct be13::ether_header *eth_header = (struct be13::ether_header *) p;
+    u_int ether_type_offset = offsetof(struct be13::ether_header, ether_type);
 
     /* Variables to support VLAN */
-    const u_short *ether_type = &eth_header->ether_type; /* where the ether type is located */
-    const u_char *ether_data = p+sizeof(struct be13::ether_header); /* where the data is located */
+    const u_short *ether_type = NULL;
+    const u_char *ether_data = NULL;
+
+    if (caplen < ether_type_offset) {
+        DEBUG(0) ("error: the captured packet header bytes are shorter than the ether_type offset");
+        return;
+    }
+
+    ether_type = &eth_header->ether_type; /* where the ether type is located */
+    ether_data = p+sizeof(struct be13::ether_header); /* where the data is located */
 
     if (length != caplen) {
 	DEBUG(6) ("warning: only captured %d bytes of %d byte ether frame",
@@ -109,6 +118,10 @@ void dl_ethernet(u_char *user, const struct pcap_pkthdr *h, const u_char *p)
 	ether_type += 2;			/* skip past VLAN header (note it skips by 2s) */
 	ether_data += 4;			/* skip past VLAN header */
 	caplen     -= 4;
+        if (caplen < ether_type_offset) {
+            DEBUG(0) ("error: the captured packet header bytes are shorter than the ether_type offset");
+            return;
+        }
     }
   
     if (caplen < sizeof(struct be13::ether_header)) {

--- a/src/tcpdemux.cpp
+++ b/src/tcpdemux.cpp
@@ -744,7 +744,7 @@ int tcpdemux::process_ip4(const be13::packet_info &pi)
     }
 
     /* do TCP processing, faking an ipv6 address  */
-    uint16_t ip_payload_len = ip_len - ip_header_len;
+    uint16_t ip_payload_len = pi.ip_datalen - ip_header_len;
     ipaddr src(ip_header->ip_src.addr);
     ipaddr dst(ip_header->ip_dst.addr);
     return (this->*tcp_processor)(src, dst ,AF_INET,

--- a/src/wifipcap/wifipcap.cpp
+++ b/src/wifipcap/wifipcap.cpp
@@ -1444,6 +1444,14 @@ void WifiPacket::handle_radiotap(const u_char *p,size_t caplen)
 
     const u_char *iter = (u_char*)(last_presentp + 1);
     struct cpack_state cpacker;
+
+
+    /* Handle malformed data */
+    if ((ssize_t)(len - (iter - p)) <= 0) {
+        cbs->HandleRadiotap( *this, NULL, p, caplen);
+        return;// caplen;
+    }
+
     if (cpack_init(&cpacker, (u_int8_t*)iter, len - (iter - p)) != 0) {
         /* XXX */
         //printf("[|802.11]");


### PR DESCRIPTION
Fuzzing with [AFL](https://lcamtuf.coredump.cx/afl/), three out-of-bound reads has been detected that could lead to application crash.

This pull request removes the out-of-bound reads identified.

The zip file [payloads.zip](https://github.com/simsong/tcpflow/files/5122280/payloads.zip) contains the payloads that trigger the bug.