### PR TITLE
Fix: support http bodies larger than 2 GB

### DIFF
--- a/src/scan_http.cpp
+++ b/src/scan_http.cpp
@@ -276,9 +276,13 @@ int scan_http_cbo::on_body(const char *at,size_t length)
 
     /* If not decompressing, just write the data and return. */
     if(unzip==false){
-        int rv = write(fd,at,length);
-        if(rv<0) return -1;             // write error; that's bad
-        bytes_written += rv;
+        size_t offset = 0;
+        while (offset < length) {
+                int rv = write(fd, at + offset, length - offset);
+                if (rv < 0) return -1;  // write error; that's bad
+                offset += rv;
+        }
+        bytes_written += offset;
         return 0;
     }
 


### PR DESCRIPTION
HTTP object export function trims the objects to 2GB due to limitations of `write` call.

See https://www.man7.org/linux/man-pages/man2/write.2.html#NOTES

```
On Linux, write() (and similar system calls) will transfer at most 0x7ffff000 (2,147,479,552) bytes, 
returning the number of bytes actually transferred.  (This is true on both 32-bit and 64-bit systems.)
```