### PR TITLE
Update travis .yml file to add support to ppc64le. Modify dist to bionic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ addons:
     - libpcap-dev
     - libcairo2-dev
 language: cpp
+arch:
+  - amd64
+  - ppc64le
+dist: bionic
 compiler: clang
 install:
  - ./bootstrap.sh && ./configure && make


### PR DESCRIPTION
Modify dist to bionic for c++17 requirements to be met. Add support to Linux on Power Little Endian architecture. tcpflow  is part of the ubuntu distribution on ppc64le as well. Continuously building/testing on this platform will help detecting/fixing issues in early stage and ensuring we are up to date.