### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/netviz/plot_view.h
+++ b/src/netviz/plot_view.h
@@ -23,6 +23,7 @@
 #include <cairo/cairo-pdf.h>
 #endif
 
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <math.h>


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so etc is no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html. Bug: https://bugs.gentoo.org/895282