### PR TITLE
Remove python27 checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -490,36 +490,6 @@ AC_CHECK_TYPES([sa_family_t], [], [],
 ]]
 )
 
-################################################################
-# Plugin scan_python.cpp requires header "Python.h"
-# If the header is not present => Disable the source code of the plugin
-#
-AC_CHECK_HEADERS(python2.7/Python.h)  # ==> #define HAVE_PYTHON2_7_PYTHON_H
-AC_CHECK_LIB(python2.7,Py_Initialize,,[
-  AC_MSG_WARN([
-*** Cannot find python library.
-*** Please install python-devel to enable scanner python.
-  ])
-  Fmissing_library="$Fmissing_library python-devel "      # Validated on Fedora 25
-  Umissing_library="$Umissing_library libpython2.7-dev"   # Should be OK: https://packages.ubuntu.com/yakkety/libpython2.7-dev
-  Mmissing_library="$Mmissing_library python27"           # Not sure: https://github.com/macports/macports-ports/blob/master/lang/python27/Portfile
-])
-
-################################################################
-# Plugin scanner_python.cpp requires header "Python.h"
-# If the header is not present => Disable the source code of the plugin
-#
-AC_CHECK_HEADERS(python2.7/Python.h)  # ==> #define HAVE_PYTHON2_7_PYTHON_H
-AC_CHECK_LIB(python2.7,Py_Initialize,,[
-  AC_MSG_WARN([
-*** Cannot find python library.
-*** Please install python-devel to enable scanner python.
-  ])
-  Fmissing_library="$Fmissing_library python-devel "      # Validated on Fedora 25
-  Umissing_library="$Umissing_library libpython2.7-dev"   # Should be OK: https://packages.ubuntu.com/yakkety/libpython2.7-dev
-  Mmissing_library="$Mmissing_library python27"           # Not sure: https://github.com/macports/macports-ports/blob/master/lang/python27/Portfile
-])
-
 ############## drop optimization flags if requested ################
 
 # Should we disable optimization?

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ check_include_files(unordered_map HAVE_UNORDERED_MAP)
 check_include_files(unordered_set HAVE_UNORDERED_SET)
 check_include_files(winsock2.h HAVE_WINSOCK2_H)
 check_include_files(zlib.h HAVE_ZLIB_H)
-check_include_files(python2.7/Python.h PYTHON2_7_PYTHON_H)  # TODO(olibre): Use instead PYTHON_INCLUDE_DIRS
+
 # There are many other #define not (yet) implemented by above CMake directives.
 # To list the #define use the following command lines:
 # sed 's|/\* ||' config.h | awk '$1 ~ /#undef|#define/{print $2}' | sort -u | while read w ; do grep -wB1 $w config.h | grep '[^ ]*> header' -q && echo $w; done > already-implemented-using-cmake-directives


### PR DESCRIPTION
tcpflow since version 1.6.1 doesn't require nor use python anymore because the only plugin which is used it (`scan_python.cpp`) was excluded from build.

Anyway, the configure complains like:
```
  *** Cannot find python library.
  *** Please install python-devel to enable scanner python.
  ...
  configure: *** You have missing libraries. To install them:
  configure: *** Red Hat: sudo yum install  python-devel  python-devel
  configure: *** Fedora:  sudo dnf install  python-devel  python-devel
  configure: *** Ubuntu:  sudo apt-get install  libpython2.7-dev libpython2.7-dev
  configure: *** MacOS:   sudo port install  python27 python27
```
which is absolutley missleading anyone who tries to build it.

Here I've cleaned it up.
