### PR TITLE
Use `-fno-new-ttp-matching` only when it is supported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ case $host in
      ;;
 
    *)
-     CXXFLAGS="$CXXFLAGS -Wno-address-of-packed-member -fno-new-ttp-matching"
+     CXXFLAGS="$CXXFLAGS -Wno-address-of-packed-member"
      ;;
 esac
 

--- a/m4/slg_gcc_all_warnings.m4
+++ b/m4/slg_gcc_all_warnings.m4
@@ -79,6 +79,7 @@ CXX_WARNINGS_TO_TEST="-Wall -MD -D_FORTIFY_SOURCE=2 -Wpointer-arith \
     -Wredundant-decls -Wdisabled-optimization \
     -Wfloat-equal -Wmultichar -Wmissing-noreturn \
     -Woverloaded-virtual -Wsign-promo \
+    -fno-new-ttp-matching \
     -funit-at-a-time"
 
 if test x"${mingw}" != "xyes" ; then


### PR DESCRIPTION
Not all compilers supported `-fno-new-ttp-matching` that literally broke tcpflow on macOS where clang is default and expected compiler.