### PR TITLE
Improve detection of `struct bpf_timeval`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -490,6 +490,19 @@ AC_CHECK_TYPES([sa_family_t], [], [],
 ]]
 )
 
+AC_CHECK_HEADERS([net/bpf.h])
+AC_CHECK_TYPES([struct bpf_timeval], [], [],
+[[
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+
+#ifdef HAVE_NET_BPF_H
+#include <net/bpf.h>
+#endif
+]]
+)
+
 ############## drop optimization flags if requested ################
 
 # Should we disable optimization?

--- a/src/tcpflow.h
+++ b/src/tcpflow.h
@@ -297,7 +297,7 @@ inline const timeval &tvshift(struct timeval &tv,const struct timeval &tv_)
     return tv;
 }
 
-#if __has_include("net/bpf.h")
+#ifdef HAVE_STRUCT_BPF_TIMEVAL
 inline const timeval &tvshift(struct timeval &tv,const struct bpf_timeval &tv_)
 {
     tv.tv_sec  = tv_.tv_sec + datalink_tdelta;


### PR DESCRIPTION
Not all system with `net/bpf.h` has `struct bpf_timeval`.

Fixes: https://github.com/simsong/tcpflow/issues/267